### PR TITLE
feat(nvim-tree): add file explorer plugin

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -36,6 +36,7 @@
   "nvim-colorizer.lua": { "branch": "master", "commit": "81e676d3203c9eb6e4c0ccf1eba1679296ef923f" },
   "nvim-cursorline": { "branch": "main", "commit": "804f0023692653b2b2368462d67d2a87056947f9" },
   "nvim-lspconfig": { "branch": "master", "commit": "2010fc6ec03e2da552b4886fceb2f7bc0fc2e9c0" },
+  "nvim-tree.lua": { "branch": "master", "commit": "31503ad5d869fca61461d82a9126f62480ecb0ab" },
   "nvim-treesitter": { "branch": "main", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-ts-autotag": { "branch": "main", "commit": "1cca23c9da708047922d3895a71032bc0449c52d" },
   "nvim-web-devicons": { "branch": "master", "commit": "8dcb311b0c92d460fac00eac706abd43d94d68af" },

--- a/lua/custom/keymaps/nvimtree.lua
+++ b/lua/custom/keymaps/nvimtree.lua
@@ -1,0 +1,3 @@
+require("globals")
+api_map("n", "<leader>te", "<cmd>NvimTreeToggle<CR>", create_desc("Toggle tree [E]xplorer"))
+api_map("n", "<leader>tr", "<cmd>NvimTreeRefresh<CR>", create_desc("Refresh tree [R]oot"))

--- a/lua/custom/keymaps/nvimtree.lua_bak
+++ b/lua/custom/keymaps/nvimtree.lua_bak
@@ -1,3 +1,0 @@
-require 'globals'
-api_map('n', '<leader>e', '<cmd>NvimTreeToggle<CR>', create_desc 'Toggle tree [E]xplorer')
-api_map('n', '<leader>r', '<cmd>NvimTreeRefresh<CR>', create_desc 'Refresh tree [R]oot')

--- a/lua/custom/plugins/nvim-tree.lua
+++ b/lua/custom/plugins/nvim-tree.lua
@@ -1,0 +1,7 @@
+return {
+    "nvim-tree/nvim-tree.lua",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+        require("nvim-tree").setup({})
+    end,
+}

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -3,7 +3,7 @@ require("custom.keymaps.generals")
 -- require 'custom.keymaps.nvchad'
 -- require 'custom.keymaps.bufferline'
 
--- require("custom.keymaps.nvimtree")
+require("custom.keymaps.nvimtree")
 require("custom.keymaps.oil")
 require("custom.keymaps.tmux")
 require("custom.keymaps.move")


### PR DESCRIPTION
Integrates the nvim-tree.lua plugin for file system navigation. Introduces new keymaps: `<leader>te` to toggle the tree and `<leader>tr` to refresh it. Removes the old `nvimtree.lua_bak` keymap file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated file tree explorer plugin. Use `<leader>te` to toggle the file tree explorer and `<leader>tr` to refresh it, providing quick access to your project structure.

* **Chores**
  * Updated keybinding configuration and plugin dependencies for improved editor integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->